### PR TITLE
Fix typo by handling from multi-press

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -673,7 +673,7 @@ class ZiGate:
             elif attribute_id == b'8000':
                 clicks = int(hexlify(attribute_data), 16)
                 self.set_device_property(device_addr, ZGT_STATE,
-                                             ZGT_STATE_MUTLI.format(clicks))
+                                             ZGT_STATE_MULTI.format(clicks))
                 _LOGGER.info('  * Multi click')
                 _LOGGER.info('  * Pressed: {} times'.format(clicks))
         # Movement


### PR DESCRIPTION
A simple typo fix, ZGT_STATE_MUTLI corrected to ZGT_STATE_MULTI