### PR TITLE
Correction of state inversion in switches

### DIFF
--- a/pyzigate/attributes_helpers.py
+++ b/pyzigate/attributes_helpers.py
@@ -62,10 +62,10 @@ class Mixin:
             ZGT_LOG.info('  * General: On/Off')
             if attribute_id == b'0000':
                 if hexlify(attribute_data) == b'00':
-                    self.set_device_property(device_addr, endpoint, ZGT_STATE, ZGT_STATE_ON)
+                    self.set_device_property(device_addr, endpoint, ZGT_STATE, ZGT_STATE_OFF)
                     ZGT_LOG.info('  * Closed/Taken off/Press')
                 else:
-                    self.set_device_property(device_addr, endpoint, ZGT_STATE, ZGT_STATE_OFF)
+                    self.set_device_property(device_addr, endpoint, ZGT_STATE, ZGT_STATE_ON)
                     ZGT_LOG.info('  * Open/Release button')
             elif attribute_id == b'8000':
                 clicks = int(hexlify(attribute_data), 16)


### PR DESCRIPTION
I don't know why you've choose to flag state ON with 00 and OFF with 01 initially but this does not work with xiaomi wall switch connected to light (see https://community.home-assistant.io/t/new-custom-component-zigate/36820/282?u=biau )
With this changes wall switch works fine but I do not have aqara push button to see if this brake something.
I did not find any attribute value in the zigbee message to differentiate switches types.